### PR TITLE
Change the package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@limkimsan/react-native-text-highlight",
+  "name": "react-native-text-highlighter",
   "version": "1.0.0",
   "description": "test",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
This pull request updates the package name from "@limkimsan/react-native-text-highlight" to "react-native-text-highlighter" because using the "@limkimsan" is a private package that requires payment.