### PR TITLE
Update the package config name to react-native-text-highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ iOS & Android
 ## Installation
 
 ```sh
-npm install react-native-text-highlight
+npm install react-native-text-highlighter
 ```
 
 #### Note:
@@ -18,7 +18,7 @@ You need to make configuration on iOS and Android by following the instruction f
 ## Usage
 
 ```js
-import TextHighlight from 'react-native-text-highlight';
+import TextHighlight from 'react-native-text-highlighter';
 
 //...
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Text } from 'react-native';
-import TextHighlight from 'react-native-text-highlight';
+import TextHighlight from 'react-native-text-highlighter';
 
 export default function App() {
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-text-highlighter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-text-highlight": ["./src/index"]
+      "react-native-text-highlighter": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
This pull request update the naming in the config file to "react-native-text-highlighter".